### PR TITLE
Copy ca-certificates from build-env image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN make
 
 FROM debian:buster-slim
 COPY --from=build-env /work/bin/gitpanda /app/gitpanda
+COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/app/gitpanda"]


### PR DESCRIPTION
`x509: certificate signed by unknown authority` error occurred when running with a docker image.
The problem is that ca-certificates do not exist in the Docker image, so copy them from the build-env image.